### PR TITLE
Support heartbeat type parameter

### DIFF
--- a/internal/bridge/subscribe.go
+++ b/internal/bridge/subscribe.go
@@ -16,7 +16,7 @@ import (
 
 var validHeartbeatTypes = map[string][]byte{
 	"legacy":  []byte("event: heartbeat\n\n"),
-	"message": []byte("event: message\ndata: heartbeat\n\n"),
+	"message": []byte("event: message\r\ndata: heartbeat\r\n\n"),
 }
 
 func (s *SSE) handleSubscribe(ctx *fasthttp.RequestCtx, ip string, authorized bool) {

--- a/internal/bridge/subscribe.go
+++ b/internal/bridge/subscribe.go
@@ -14,8 +14,6 @@ import (
 	"tonconnect-bridge/internal/bridge/metrics"
 )
 
-var heartbeat = []byte("event: message\r\ndata: heartbeat\r\n\n")
-
 func (s *SSE) handleSubscribe(ctx *fasthttp.RequestCtx, ip string, authorized bool) {
 	idsStr := string(ctx.QueryArgs().Peek("client_id"))
 	if len(idsStr) == 0 {

--- a/internal/bridge/subscribe.go
+++ b/internal/bridge/subscribe.go
@@ -16,7 +16,7 @@ import (
 
 var validHeartbeatTypes = map[string][]byte{
 	"legacy":  []byte("event: heartbeat\n\n"),
-	"message": []byte("event: message\r\ndata: heartbeat\r\n\n"),
+	"message": []byte("event: message\r\ndata: heartbeat\r\n\r\n"),
 }
 
 func (s *SSE) handleSubscribe(ctx *fasthttp.RequestCtx, ip string, authorized bool) {


### PR DESCRIPTION
https://github.com/ton-blockchain/ton-connect/pull/93/

I test it locally

```
# backwards compatibility
curl "http://localhost:8080/bridge/events?client_id=test_valid"  

event: heartbeat

event: heartbeat

# invalid type
curl "http://localhost:8080/bridge/events?client_id=test_valid&heartbeat=callmedenchick"

{"message":"invalid heartbeat type. Supported: legacy and message","statusCode":400}

# legacy type
curl "http://localhost:8080/bridge/events?client_id=test_valid&heartbeat=legacy"        

event: heartbeat

event: heartbeat

# message type
curl "http://localhost:8080/bridge/events?client_id=test_valid&heartbeat=message" 

event: message
data: heartbeat
```